### PR TITLE
Use real date of announcements in generating the feeds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ on: push
 
 name: CI
 
+env:
+  TZ: Asia/Tokyo
+
 jobs:
   lint:
     name: Lint

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/puppeteer": "5.4.5",
     "@typescript-eslint/eslint-plugin": "5.15.0",
     "@typescript-eslint/parser": "5.15.0",
+    "date-fns": "^2.28.0",
     "eslint": "8.11.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "^2.25.4",

--- a/src/feeds.ts
+++ b/src/feeds.ts
@@ -19,8 +19,7 @@ export const generateFeed = (announcements: Announcement[]): Feeds => {
       title,
       description: text,
       link: url,
-      // date,
-      date: new Date(),
+      date,
     });
   });
 

--- a/src/getAnnouncements.ts
+++ b/src/getAnnouncements.ts
@@ -1,3 +1,4 @@
+import { parse } from "date-fns";
 import md5 from "md5";
 import puppeteer, { ElementHandle } from "puppeteer";
 
@@ -10,7 +11,7 @@ const getAnnouncementBody = async ({
 }: {
   page: puppeteer.Page;
   title: string;
-  date: string;
+  date: Date;
 }): Promise<Announcement> => {
   const targetIFrame: ElementHandle<HTMLIFrameElement> | null = await page.$(
     "iframe#main-frame-if",
@@ -125,12 +126,19 @@ export const getAnnouncements = async ({
         };
       }, announcementItem);
 
+      /**
+       * Published time is not shown in TWINS, so assume it's noon JST
+       */
+      const parsedDate = parse(`${date} 12:00`, "y/M/d H:mm", new Date());
+
       const anchorElement = await announcementItem.$("a");
       await anchorElement?.click();
       await page.waitForTimeout(1000);
       await waitForAnnouncementToBeLoaded({ page });
 
-      announcements.push(await getAnnouncementBody({ page, title, date }));
+      announcements.push(
+        await getAnnouncementBody({ page, title, date: parsedDate }),
+      );
     }
 
     return announcements;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ export type Announcement = Readonly<{
   id: string;
   title: string;
   text: string;
-  date: string;
+  date: Date;
   url: string;
 }>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -403,6 +403,11 @@ crypt@0.0.2:
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
 debug@4, debug@^4.1.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"


### PR DESCRIPTION
- Add `date-fns` package
- Pass real date of announcements after parsing into `Date` object
- Set timezone in GitHub Actions
