### PR TITLE
Enable to skip full announcements fetch when no new announcement is published

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
     timeout-minutes: 30
     env:
       HEADLESS: true
+      FORCE_FULL_FETCH: true
       FEED_ITEMS_NUMBER: 2
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy-force-full.yaml
+++ b/.github/workflows/deploy-force-full.yaml
@@ -1,11 +1,8 @@
 on:
-  push:
-    branches:
-      - main
   schedule:
-    - cron: "0 */1 * * *"
+    - cron: "0 9/6 * * *"
 
-name: Deploy
+name: Deploy - Force full fetch
 
 env:
   TZ: Asia/Tokyo
@@ -17,12 +14,9 @@ jobs:
     timeout-minutes: 30
     env:
       HEADLESS: true
+      FORCE_FULL_FETCH: true
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
-        with:
-          ref: dist
-          path: dist
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,6 +19,10 @@ jobs:
       HEADLESS: true
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          ref: dist
+          path: dist
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.25.4",
     "feed": "4.2.2",
+    "fp-ts": "^2.11.9",
     "md5": "2.3.0",
     "prettier": "2.6.0",
     "puppeteer": "13.5.1",

--- a/src/getLatestAnnouncementTitle.ts
+++ b/src/getLatestAnnouncementTitle.ts
@@ -1,0 +1,23 @@
+import * as O from "fp-ts/Option";
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import path from "path";
+
+const filePath = path.resolve("dist", "latestAnnouncementTitle");
+
+export const getLatestAnnouncementTitle = async (): Promise<
+  O.Option<string>
+> => {
+  try {
+    if (!existsSync(filePath)) return O.none;
+
+    const titleBuffer = await readFile(filePath);
+
+    return O.some(titleBuffer.toString());
+  } catch (err) {
+    console.error(err);
+    throw new Error(
+      "Failed to read title of latest announcement from the file",
+    );
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -785,6 +785,11 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.1.tgz#bbef080d95fca6709362c73044a1634f7c6e7d05"
   integrity sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==
 
+fp-ts@^2.11.9:
+  version "2.11.9"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.11.9.tgz#bbc204e0932954b59c98a282635754a4b624a05e"
+  integrity sha512-GhYlNKkCOfdjp71ocdtyaQGoqCswEoWDJLRr+2jClnBBq2dnSOtd6QxmJdALq8UhfqCyZZ0f0lxadU4OhwY9nw==
+
 fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"


### PR DESCRIPTION
- Add `fp-ts` package
- Enable to skip full announcements fetch when no new announcement is published
- Checkout `dist` branch into `dist` dir in `deploy` workflow
- Run normal deploy every 1hrs and full deploy every 6hrs
