### PR TITLE
Migrate to `moduleResolution: "Node16"`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 eslint = yarn run eslint --ignore-path .gitignore
 prettier = yarn run prettier --ignore-path .gitignore
 typecheck = yarn run tsc --noEmit
-ts-node = node --loader ts-node/esm --experimental-specifier-resolution=node
+ts-node = node --loader ts-node/esm
 
 node_modules: package.json yarn.lock
 ifeq ($(MAKE_YARN_FROZEN_LOCKFILE), 1)

--- a/src/feeds.ts
+++ b/src/feeds.ts
@@ -2,7 +2,7 @@ import { Feed } from "feed";
 import { writeFile, mkdir } from "fs/promises";
 import path from "path";
 
-import { Announcement, Feeds } from "./types";
+import { Announcement, Feeds } from "./types/index.js";
 
 export const generateFeed = (announcements: Announcement[]): Feeds => {
   const feedClient = new Feed({

--- a/src/getAnnouncements.ts
+++ b/src/getAnnouncements.ts
@@ -1,10 +1,10 @@
 import { parse } from "date-fns";
-import * as O from "fp-ts/lib/Option";
+import * as O from "fp-ts/lib/Option.js";
 import md5 from "md5";
 import { Page } from "puppeteer";
 
-import { getLatestAnnouncementTitle } from "./getLatestAnnouncementTitle";
-import type { Announcement } from "./types";
+import { getLatestAnnouncementTitle } from "./getLatestAnnouncementTitle.js";
+import type { Announcement } from "./types/index.js";
 
 const getAnnouncementBody = async (
   page: Page,

--- a/src/getLatestAnnouncementTitle.ts
+++ b/src/getLatestAnnouncementTitle.ts
@@ -1,4 +1,4 @@
-import * as O from "fp-ts/lib/Option";
+import * as O from "fp-ts/lib/Option.js";
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import path from "path";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-import * as O from "fp-ts/lib/Option";
+import * as O from "fp-ts/lib/Option.js";
 import puppeteer from "puppeteer";
 
-import { generateFeed, saveFeedToFiles } from "./feeds";
-import { getAnnouncements } from "./getAnnouncements";
-import { saveLatestAnnouncementTitle } from "./saveLatestAnnouncementTitle";
+import { generateFeed, saveFeedToFiles } from "./feeds.js";
+import { getAnnouncements } from "./getAnnouncements.js";
+import { saveLatestAnnouncementTitle } from "./saveLatestAnnouncementTitle.js";
 
 const HEADLESS = process.env.HEADLESS === "true";
 const FORCE_FULL_FETCH = process.env.FORCE_FULL_FETCH === "true";

--- a/src/saveLatestAnnouncementTitle.ts
+++ b/src/saveLatestAnnouncementTitle.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 
-import type { Announcement } from "./types";
+import type { Announcement } from "./types/index.js";
 
 export const saveLatestAnnouncementTitle = async (
   announcements: Announcement[],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "lib": ["DOM"],
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
- Migrate to `moduleResolution: "Node16"`
- Disable `experimental-specifier-resolution=node` option of Node
